### PR TITLE
Timestep Example

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -22,20 +22,20 @@ set(CMAKE_CXX_EXTENSIONS NO)
 add_executable(generalgraph generalgraph.cpp)
 target_link_libraries(generalgraph smoothG)
 
-add_executable(poweriter poweriter.cpp)
-target_link_libraries(poweriter smoothG)
+add_executable(timestep timestep.cpp)
+target_link_libraries(timestep smoothG)
 
 add_executable(graphupscale graphupscale.cpp)
 target_link_libraries(graphupscale smoothG)
+
+add_executable(poweriter poweriter.cpp)
+target_link_libraries(poweriter smoothG)
 
 add_executable(mltopo mltopo.cpp)
 target_link_libraries(mltopo smoothG)
 
 add_executable(mlmc mlmc.cpp)
 target_link_libraries(mlmc smoothG)
-
-add_executable(timestep timestep.cpp)
-target_link_libraries(timestep smoothG)
 
 if (NOT DEFINED SMOOTHG_TEST_TOL)
     set(SMOOTHG_TEST_TOL 1e-4)
@@ -57,6 +57,7 @@ add_test(samplegraph4 python stest.py samplegraph4)
 add_test(graph-hybridization python stest.py graph-hybridization)
 add_test(poweriter python stest.py poweriter)
 add_test(graph-weight python stest.py graph-weight)
+add_test(timestep python stest.py timestep)
 add_test(graphupscale graphupscale)
 add_test(mltopo mltopo)
 add_test(mlmc mlmc)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -34,6 +34,9 @@ target_link_libraries(mltopo smoothG)
 add_executable(mlmc mlmc.cpp)
 target_link_libraries(mlmc smoothG)
 
+add_executable(timestep timestep.cpp)
+target_link_libraries(timestep smoothG)
+
 if (NOT DEFINED SMOOTHG_TEST_TOL)
     set(SMOOTHG_TEST_TOL 1e-4)
 endif()

--- a/examples/stest.py
+++ b/examples/stest.py
@@ -249,6 +249,10 @@ def make_tests():
           "finest-u-error": 0.14767829457535478,
           "operator-complexity": 1.1666666666666667}]
 
+    tests["timestep"] = \
+        [["./timestep",
+          "--time", "100.0"]]
+
     tests["pareigenvector1"] = \
         [["mpirun", "-n", num_procs, "./generalgraph",
           "--g", graph_data + "/fe_vertex_edge.txt",
@@ -359,6 +363,10 @@ def make_tests():
           "coarse-eval": 0.17663653207421526,
           "fine-error": 2.9887390635842169e-05,
           "fine-eval": 0.17545528997977797}]
+
+    tests["partimestep"] = \
+        [["mpirun", "-n", num_procs, "./timestep",
+          "--time", "100.0"]]
 
     # tests["isolate-coarsen"] = \
     #     [["./generalgraph",

--- a/examples/timestep.cpp
+++ b/examples/timestep.cpp
@@ -14,7 +14,6 @@
  ***********************************************************************EHEADER*/
 
 /**
-   @example
    @file timestep.cpp
    @brief Visualized pressure over time of a simple reservior model.
 */
@@ -126,8 +125,8 @@ int main(int argc, char* argv[])
     // Set up GraphUpscale
     /// [Upscale]
     GraphUpscale upscale(comm, vertex_edge_global, global_partitioning,
-            spect_tol, max_evects, hybridization,
-            weight, W_block);
+                         spect_tol, max_evects, hybridization,
+                         weight, W_block);
 
     upscale.PrintInfo();
     upscale.ShowSetupTime();
@@ -233,7 +232,6 @@ int main(int argc, char* argv[])
 
         chrono.Click();
     }
-
 
     ParPrint(myid, std::cout << "Total Time: " << chrono.TotalTime() << "\n");
 

--- a/examples/timestep.cpp
+++ b/examples/timestep.cpp
@@ -1,0 +1,253 @@
+/*BHEADER**********************************************************************
+ *
+ * Copyright (c) 2018, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ * LLNL-CODE-745247. All Rights reserved. See file COPYRIGHT for details.
+ *
+ * This file is part of smoothG. For more information and source code
+ * availability, see https://www.github.com/llnl/smoothG.
+ *
+ * smoothG is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ ***********************************************************************EHEADER*/
+
+/**
+   @example
+   @file timestep.cpp
+   @brief Visualized pressure over time of a simple reservior model.
+*/
+
+#include <fstream>
+#include <sstream>
+#include <mpi.h>
+
+#include "smoothG.hpp"
+
+using namespace smoothg;
+
+using linalgcpp::ReadText;
+using linalgcpp::WriteText;
+using linalgcpp::ReadCSR;
+
+std::vector<int> MetisPart(const SparseMatrix& vertex_edge, int num_parts);
+
+int main(int argc, char* argv[])
+{
+    // Initialize MPI
+    MpiSession mpi_info(argc, argv);
+    MPI_Comm comm = mpi_info.comm_;
+    int myid = mpi_info.myid_;
+    int num_procs = mpi_info.num_procs_;
+
+    // program options from command line
+    std::string graph_filename = "../../graphdata/fe_vertex_edge.txt";
+    std::string fiedler_filename = "../../graphdata/fe_rhs.txt";
+    std::string partition_filename = "../../graphdata/fe_part.txt";
+    std::string weight_filename = "../../graphdata/fe_weight_0.txt";
+    std::string output_dir = "timestep_out/";
+
+    int max_evects = 4;
+    double spect_tol = 1e-3;
+    int num_partitions = 12;
+    bool hybridization = false;
+    bool metis_agglomeration = false;
+
+    double delta_t = 10.0;
+    double total_time = 10000.0;
+    int vis_step = 0;
+    int k = 1;
+
+    linalgcpp::ArgParser arg_parser(argc, argv);
+
+    arg_parser.Parse(graph_filename, "--g", "Graph connection data.");
+    arg_parser.Parse(fiedler_filename, "--f", "Fiedler vector data.");
+    arg_parser.Parse(partition_filename, "--p", "Partition data.");
+    arg_parser.Parse(weight_filename, "--w", "Edge weight data.");
+    arg_parser.Parse(max_evects, "--m", "Maximum eigenvectors per aggregate.");
+    arg_parser.Parse(spect_tol, "--t", "Spectral tolerance for eigenvalue problem.");
+    arg_parser.Parse(num_partitions, "--np", "Number of partitions to generate.");
+    arg_parser.Parse(hybridization, "--hb", "Enable hybridization.");
+    arg_parser.Parse(metis_agglomeration, "--ma", "Enable Metis partitioning.");
+    arg_parser.Parse(delta_t, "--dt", "Delta t for time step.");
+    arg_parser.Parse(total_time, "--time", "Total time to step.");
+    arg_parser.Parse(vis_step, "--vs", "Step size for visualization.");
+    arg_parser.Parse(k, "--k", "Level. Fine = 0, Coarse = 1");
+
+    if (!arg_parser.IsGood())
+    {
+        ParPrint(myid, arg_parser.ShowHelp());
+        ParPrint(myid, arg_parser.ShowErrors());
+
+        return EXIT_FAILURE;
+    }
+
+    ParPrint(myid, arg_parser.ShowOptions());
+
+    assert(k == 0 || k == 1);
+
+    /// [Load graph from file]
+    SparseMatrix vertex_edge_global = ReadCSR(graph_filename);
+
+    const int nvertices_global = vertex_edge_global.Rows();
+    const int nedges_global = vertex_edge_global.Cols();
+    /// [Load graph from file or generate one]
+
+    /// [Partitioning]
+    std::vector<int> global_partitioning;
+    if (metis_agglomeration)
+    {
+        assert(num_partitions >= num_procs);
+        global_partitioning = MetisPart(vertex_edge_global, num_partitions);
+    }
+    else
+    {
+        global_partitioning = ReadText<int>(partition_filename);
+    }
+    /// [Partitioning]
+
+    /// [Load the edge weights]
+    std::vector<double> weight;
+    if (!weight_filename.empty())
+    {
+        weight = linalgcpp::ReadText(weight_filename);
+    }
+    else
+    {
+        weight = std::vector<double>(nedges_global, 1.0);
+    }
+    /// [Load the edge weights]
+
+    SparseMatrix W_block = SparseIdentity(nvertices_global);;
+    double alpha = 200.0;
+    W_block *= alpha / delta_t;
+
+    // Set up GraphUpscale
+    /// [Upscale]
+    GraphUpscale upscale(comm, vertex_edge_global, global_partitioning,
+            spect_tol, max_evects, hybridization,
+            weight, W_block);
+
+    upscale.PrintInfo();
+    upscale.ShowSetupTime();
+    /// [Upscale]
+
+    /// [Right Hand Side]
+    BlockVector fine_rhs = upscale.GetFineBlockVector();
+    fine_rhs.GetBlock(0) = 0.0;
+    fine_rhs.GetBlock(1) = upscale.ReadVertexVector(fiedler_filename);
+    /// [Right Hand Side]
+
+    /// [Time Step]
+    std::vector<std::vector<int>> offsets{upscale.FineBlockOffsets(), upscale.CoarseBlockOffsets()};
+
+    BlockVector fine_u = upscale.GetFineBlockVector();
+    fine_u.GetBlock(0) = 0.0;
+
+    // Set initial condition
+    {
+        Vector u_half(nvertices_global);
+        int half = nvertices_global / 2;
+
+        std::fill(std::begin(u_half), std::begin(u_half) + half, -1.0);
+        std::fill(std::begin(u_half) + half, std::end(u_half), 1.0);
+
+        fine_u.GetBlock(1) = upscale.GetVertexVector(u_half);
+    }
+
+    BlockVector tmp(offsets[k]);
+    tmp = 0.0;
+
+    BlockVector work_rhs(offsets[k]);
+    BlockVector work_u(offsets[k]);
+
+    if (k == 0)
+    {
+        work_rhs = fine_rhs;
+        work_u = fine_u;
+    }
+    else
+    {
+        upscale.Restrict(fine_u, work_u);
+        upscale.Restrict(fine_rhs, work_rhs);
+    }
+
+    const SparseMatrix& W = upscale.GetMatrix(k).LocalW();
+
+    upscale.ShowSetupTime();
+
+    double time = 0.0;
+    int count = 0;
+
+    if (vis_step > 0)
+    {
+        std::stringstream ss;
+        ss << "timestep_out/" << std::setw(5) << std::setfill('0') << count << ".txt";
+
+        upscale.WriteVertexVector(fine_u.GetBlock(1), ss.str());
+    }
+
+    Timer chrono(Timer::Start::True);
+
+    while (time < total_time)
+    {
+        W.Mult(work_u.GetBlock(1), tmp.GetBlock(1));
+
+        //tmp += work_rhs; // RHS is zero for now
+        tmp *= -1.0;
+
+        if (k == 0)
+        {
+            upscale.SolveFine(tmp, work_u);
+        }
+        else
+        {
+            upscale.SolveCoarse(tmp, work_u);
+        }
+
+        if (myid == 0)
+        {
+            std::cout << std::fixed << std::setw(8) << count << "\t" << time << "\n";
+        }
+
+        time += delta_t;
+        count++;
+
+        if (vis_step > 0 && count % vis_step == 0)
+        {
+            if (k == 0)
+            {
+                fine_u.GetBlock(1) = work_u.GetBlock(1);
+            }
+            else
+            {
+                upscale.Interpolate(work_u.GetBlock(1), fine_u.GetBlock(1));
+            }
+
+            std::stringstream ss;
+            ss << output_dir << std::setw(5) << std::setfill('0') << count << ".txt";
+
+            upscale.WriteVertexVector(fine_u.GetBlock(1), ss.str());
+        }
+
+        chrono.Click();
+    }
+
+
+    ParPrint(myid, std::cout << "Total Time: " << chrono.TotalTime() << "\n");
+
+    /// [Time Step]
+
+    return 0;
+}
+
+std::vector<int> MetisPart(const SparseMatrix& vertex_edge, int num_parts)
+{
+    SparseMatrix edge_vertex = vertex_edge.Transpose();
+    SparseMatrix vertex_vertex = vertex_edge.Mult(edge_vertex);
+
+    double ubal_tol = 2.0;
+
+    return Partition(vertex_vertex, num_parts, ubal_tol);
+}

--- a/include/GraphUpscale.hpp
+++ b/include/GraphUpscale.hpp
@@ -86,11 +86,11 @@ public:
                  const SparseMatrix& W_block_global = SparseMatrix());
 
     /// Extract a local fine vertex space vector from global vector
-    template <typename T = VectorView>
+    template <typename T>
     T GetVertexVector(const T& global_vect) const;
 
     /// Extract a local fine edge space vector from global vector
-    template <typename T = VectorView>
+    template <typename T>
     T GetEdgeVector(const T& global_vect) const;
 
     /// Read permuted vertex vector
@@ -150,13 +150,13 @@ T GetSubVector(const T& global_vect, const std::vector<int>& map)
 
 }
 
-template <typename T = VectorView>
+template <typename T>
 T GraphUpscale::GetVertexVector(const T& global_vect) const
 {
     return GetSubVector(global_vect, graph_.vertex_map_);
 }
 
-template <typename T = VectorView>
+template <typename T>
 T GraphUpscale::GetEdgeVector(const T& global_vect) const
 {
     return GetSubVector(global_vect, graph_.vertex_map_);

--- a/include/GraphUpscale.hpp
+++ b/include/GraphUpscale.hpp
@@ -134,22 +134,6 @@ private:
     GraphTopology gt_;
 };
 
-template <typename T = VectorView>
-T GetSubVector(const T& global_vect, const std::vector<int>& map)
-{
-    int size = map.size();
-
-    T local_vect(size);
-
-    for (int i = 0; i < size; ++i)
-    {
-        local_vect[i] = global_vect[map[i]];
-    }
-
-    return local_vect;
-
-}
-
 template <typename T>
 T GraphUpscale::GetVertexVector(const T& global_vect) const
 {

--- a/include/GraphUpscale.hpp
+++ b/include/GraphUpscale.hpp
@@ -62,7 +62,8 @@ public:
                  const SparseMatrix& vertex_edge_global,
                  double coarse_factor, double spect_tol = 0.001,
                  int max_evects = 4, bool hybridization = false,
-                 const std::vector<double>& weight_global = {});
+                 const std::vector<double>& weight_global = {},
+                 const SparseMatrix& W_block_global = SparseMatrix());
 
     /**
        @brief Constructor
@@ -81,7 +82,16 @@ public:
                  const std::vector<int>& partitioning_global,
                  double spect_tol = 0.001, int max_evects = 4,
                  bool hybridization = false,
-                 const std::vector<double>& weight_global = {});
+                 const std::vector<double>& weight_global = {},
+                 const SparseMatrix& W_block_global = SparseMatrix());
+
+    /// Extract a local fine vertex space vector from global vector
+    template <typename T = VectorView>
+    T GetVertexVector(const T& global_vect) const;
+
+    /// Extract a local fine edge space vector from global vector
+    template <typename T = VectorView>
+    T GetEdgeVector(const T& global_vect) const;
 
     /// Read permuted vertex vector
     Vector ReadVertexVector(const std::string& filename) const;
@@ -123,6 +133,34 @@ private:
     Graph graph_;
     GraphTopology gt_;
 };
+
+template <typename T = VectorView>
+T GetSubVector(const T& global_vect, const std::vector<int>& map)
+{
+    int size = map.size();
+
+    T local_vect(size);
+
+    for (int i = 0; i < size; ++i)
+    {
+        local_vect[i] = global_vect[map[i]];
+    }
+
+    return local_vect;
+
+}
+
+template <typename T = VectorView>
+T GraphUpscale::GetVertexVector(const T& global_vect) const
+{
+    return GetSubVector(global_vect, graph_.vertex_map_);
+}
+
+template <typename T = VectorView>
+T GraphUpscale::GetEdgeVector(const T& global_vect) const
+{
+    return GetSubVector(global_vect, graph_.vertex_map_);
+}
 
 } // namespace smoothg
 

--- a/include/Utilities.hpp
+++ b/include/Utilities.hpp
@@ -360,6 +360,28 @@ void WriteVector(MPI_Comm comm, const T& vect, const std::string& filename, int 
 */
 std::vector<int> GetElementColoring(const SparseMatrix& el_el);
 
+/**
+   @brief Extract a subvector from a vector
+
+   @param global_vect global vector from which to extract
+   @param map indices to extract
+   @returns subvector
+*/
+template <typename T = VectorView>
+T GetSubVector(const T& global_vect, const std::vector<int>& map)
+{
+    int size = map.size();
+
+    T local_vect(size);
+
+    for (int i = 0; i < size; ++i)
+    {
+        local_vect[i] = global_vect[map[i]];
+    }
+
+    return local_vect;
+}
+
 } //namespace smoothg
 
 #endif // __UTILITIES_HPP__

--- a/src/GraphUpscale.cpp
+++ b/src/GraphUpscale.cpp
@@ -27,7 +27,8 @@ GraphUpscale::GraphUpscale(MPI_Comm comm,
                            const SparseMatrix& vertex_edge_global,
                            double coarse_factor, double spect_tol,
                            int max_evects, bool hybridization,
-                           const std::vector<double>& weight_global)
+                           const std::vector<double>& weight_global,
+                           const SparseMatrix& W_block_global)
     : GraphUpscale(comm, vertex_edge_global, PartitionAAT(vertex_edge_global, coarse_factor),
                    spect_tol, max_evects, hybridization, weight_global)
 {
@@ -38,7 +39,8 @@ GraphUpscale::GraphUpscale(MPI_Comm comm,
                            const SparseMatrix& vertex_edge_global,
                            const std::vector<int>& partitioning_global,
                            double spect_tol, int max_evects, bool hybridization,
-                           const std::vector<double>& weight_global)
+                           const std::vector<double>& weight_global,
+                           const SparseMatrix& W_block_global)
     : Upscale(comm, vertex_edge_global, hybridization),
       spect_tol_(spect_tol), max_evects_(max_evects)
 {
@@ -47,7 +49,7 @@ GraphUpscale::GraphUpscale(MPI_Comm comm,
     graph_ = Graph(comm_, vertex_edge_global, partitioning_global);
     gt_ = GraphTopology(graph_);
 
-    VectorElemMM fine_mm(graph_, weight_global);
+    VectorElemMM fine_mm(graph_, weight_global, W_block_global);
     fine_mm.AssembleM(); // Coarsening requires assembled M, for now
 
     coarsener_ = GraphCoarsen(fine_mm, gt_, max_evects_, spect_tol_);


### PR DESCRIPTION
Adds timestep example to showcase the `W` block.

# SPE10 Slice 0 - Diffusion Over Time
### Fine Level
![fine_diff](https://user-images.githubusercontent.com/13111488/39591082-81182664-4eb7-11e8-8899-a602ed201ac7.gif)

### Coarse Approximations
Increasing from 1 basis vector per aggregate to 4
![all](https://user-images.githubusercontent.com/13111488/39591926-1fd53b14-4eba-11e8-930a-b54bd347b2be.gif)