### PR TITLE
Clean up parameters, Graph structure

### DIFF
--- a/examples/Sampler.hpp
+++ b/examples/Sampler.hpp
@@ -33,12 +33,12 @@ namespace smoothg
     @param index filename suffix
 */
 template <typename T>
-void SaveOutput(const GraphUpscale& upscale, const T& vect, const std::string& prefix, int index)
+void SaveOutput(const Graph& graph, const T& vect, const std::string& prefix, int index)
 {
     std::stringstream ss;
     ss << prefix << std::setw(5) << std::setfill('0') << index << ".txt";
 
-    upscale.WriteVertexVector(vect, ss.str());
+    WriteVertexVector(graph, vect, ss.str());
 }
 
 /** @brief Scalar normal distribution */
@@ -85,7 +85,7 @@ public:
         @param kappa inverse correlation length for Matern covariance
         @param seed seed for random number generator
      */
-    PDESampler(Graph graph, const UpscaleParams& params,
+    PDESampler(const Graph& graph, const UpscaleParams& params,
                int dimension, double kappa, double cell_volume, int seed);
 
     /** @brief Default Destructor */
@@ -147,9 +147,9 @@ private:
 };
 
 
-PDESampler::PDESampler(Graph graph, const UpscaleParams& params,
+PDESampler::PDESampler(const Graph& graph, const UpscaleParams& params,
                        int dimension, double kappa, double cell_volume, int seed)
-    : upscale_(std::move(graph), params),
+    : upscale_(graph, params),
       normal_dist_(0.0, 1.0, seed),
       cell_volume_(cell_volume),
       rhs_fine_(upscale_.GetVector(0)),

--- a/examples/Sampler.hpp
+++ b/examples/Sampler.hpp
@@ -85,7 +85,7 @@ public:
         @param kappa inverse correlation length for Matern covariance
         @param seed seed for random number generator
      */
-    PDESampler(Graph graph, double spect_tol, int max_evects, bool hybridization,
+    PDESampler(Graph graph, const UpscaleParams& params,
                int dimension, double kappa, double cell_volume, int seed);
 
     /** @brief Default Destructor */
@@ -147,9 +147,9 @@ private:
 };
 
 
-PDESampler::PDESampler(Graph graph, double spect_tol, int max_evects, bool hybridization,
+PDESampler::PDESampler(Graph graph, const UpscaleParams& params,
                        int dimension, double kappa, double cell_volume, int seed)
-    : upscale_(std::move(graph), spect_tol, max_evects, hybridization),
+    : upscale_(std::move(graph), params),
       normal_dist_(0.0, 1.0, seed),
       cell_volume_(cell_volume),
       rhs_fine_(upscale_.GetVector(0)),

--- a/examples/generalgraph.cpp
+++ b/examples/generalgraph.cpp
@@ -52,12 +52,14 @@ int main(int argc, char* argv[])
     std::string weight_filename = "";
     std::string w_block_filename = "";
 
+
     int isolate = -1;
+    int num_partitions = 12;
+    bool metis_agglomeration = false;
+
     int max_evects = 4;
     double spect_tol = 1e-3;
-    int num_partitions = 12;
     bool hybridization = false;
-    bool metis_agglomeration = false;
     int num_levels = 2;
 
     bool generate_fiedler = false;
@@ -145,7 +147,7 @@ int main(int argc, char* argv[])
     // Set up GraphUpscale
     /// [Upscale]
     Graph graph(comm, vertex_edge_global, global_partitioning, weight);
-    GraphUpscale upscale(graph, spect_tol, max_evects, hybridization, num_levels);
+    GraphUpscale upscale(graph, {spect_tol, max_evects, hybridization, num_levels});
 
     upscale.PrintInfo();
     upscale.ShowSetupTime();

--- a/examples/generalgraph.cpp
+++ b/examples/generalgraph.cpp
@@ -163,7 +163,7 @@ int main(int argc, char* argv[])
     }
     else
     {
-        fine_rhs.GetBlock(1) = upscale.ReadVertexVector(fiedler_filename);
+        fine_rhs.GetBlock(1) = ReadVertexVector(graph, fiedler_filename);
     }
 
     /// [Right Hand Side]
@@ -185,7 +185,7 @@ int main(int argc, char* argv[])
 
     if (save_fiedler)
     {
-        upscale.WriteVertexVector(fine_rhs.GetBlock(1), fiedler_filename);
+        WriteVertexVector(graph, fine_rhs.GetBlock(1), fiedler_filename);
     }
 
     return EXIT_SUCCESS;
@@ -212,8 +212,6 @@ Vector ComputeFiedlerVector(const MixedMatrix& mgl)
         A.AddDiag(1.0);
     }
 
-    BoomerAMG boomer(A);
-
     int num_evects = 2;
     std::vector<Vector> evects(num_evects, Vector(A.Rows()));
     for (Vector& evect : evects)
@@ -221,6 +219,7 @@ Vector ComputeFiedlerVector(const MixedMatrix& mgl)
         evect.Randomize();
     }
 
+    BoomerAMG boomer(A);
     std::vector<double> evals = LOBPCG(A, evects, &boomer);
 
     assert(static_cast<int>(evals.size()) == num_evects);

--- a/examples/graphupscale.cpp
+++ b/examples/graphupscale.cpp
@@ -63,7 +63,7 @@ int main(int argc, char* argv[])
         std::vector<int> part = PartitionAAT(vertex_edge, coarse_factor);
         Graph graph(comm, vertex_edge, part);
 
-        GraphUpscale upscale(graph, spect_tol, max_evects, hybridization);
+        GraphUpscale upscale(graph, {spect_tol, max_evects, hybridization});
 
         Vector rhs_u_fine = upscale.ReadVertexVector(rhs_filename);
         Vector sol = upscale.Solve(rhs_u_fine);
@@ -84,7 +84,7 @@ int main(int argc, char* argv[])
 
         // Use distrubted constructor
         Graph graph_local(vertex_edge_local, edge_true_edge, part_local, weight_local);
-        GraphUpscale upscale(graph_local, spect_tol, max_evects, hybridization);
+        GraphUpscale upscale(graph_local, {spect_tol, max_evects, hybridization});
 
         // This right hand side may not be permuted the same as in the upscaler,
         // since only local vertex information was given and the vertex map was generated
@@ -99,7 +99,7 @@ int main(int argc, char* argv[])
         std::vector<int> part = PartitionAAT(vertex_edge, coarse_factor);
         Graph graph(comm, vertex_edge, part);
 
-        GraphUpscale upscale(graph, spect_tol, max_evects, hybridization);
+        GraphUpscale upscale(graph, {spect_tol, max_evects, hybridization});
 
         // Start at Fine Level
         Vector rhs_u_fine = upscale.ReadVertexVector(rhs_filename);
@@ -126,7 +126,7 @@ int main(int argc, char* argv[])
         std::vector<int> part = PartitionAAT(vertex_edge, coarse_factor);
         Graph graph(comm, vertex_edge, part);
 
-        GraphUpscale upscale(graph, spect_tol, max_evects, hybridization);
+        GraphUpscale upscale(graph, {spect_tol, max_evects, hybridization});
 
         BlockVector fine_rhs = upscale.ReadVertexBlockVector(rhs_filename);
 
@@ -153,8 +153,8 @@ int main(int argc, char* argv[])
 
         bool use_hybridization = true;
 
-        GraphUpscale hb_upscale(graph, spect_tol, max_evects, use_hybridization);
-        GraphUpscale minres_upscale(graph, spect_tol, max_evects, !use_hybridization);
+        GraphUpscale hb_upscale(graph, {spect_tol, max_evects, use_hybridization});
+        GraphUpscale minres_upscale(graph, {spect_tol, max_evects, !use_hybridization});
 
         Vector rhs_u_fine = minres_upscale.ReadVertexVector(rhs_filename);
 

--- a/examples/graphupscale.cpp
+++ b/examples/graphupscale.cpp
@@ -65,10 +65,10 @@ int main(int argc, char* argv[])
 
         GraphUpscale upscale(graph, {spect_tol, max_evects, hybridization});
 
-        Vector rhs_u_fine = upscale.ReadVertexVector(rhs_filename);
+        Vector rhs_u_fine = ReadVertexVector(graph, rhs_filename);
         Vector sol = upscale.Solve(rhs_u_fine);
 
-        upscale.WriteVertexVector(sol, "sol1.out");
+        WriteVertexVector(graph, sol, "sol1.out");
     }
 
     // Mimic distributed data
@@ -88,10 +88,10 @@ int main(int argc, char* argv[])
 
         // This right hand side may not be permuted the same as in the upscaler,
         // since only local vertex information was given and the vertex map was generated
-        Vector rhs_u_fine = upscale.ReadVertexVector(rhs_filename);
+        Vector rhs_u_fine = ReadVertexVector(graph_local, rhs_filename);
         Vector sol = upscale.Solve(rhs_u_fine);
 
-        upscale.WriteVertexVector(sol, "sol2.out");
+        WriteVertexVector(graph_local, sol, "sol2.out");
     }
 
     // Using coarse space
@@ -102,7 +102,7 @@ int main(int argc, char* argv[])
         GraphUpscale upscale(graph, {spect_tol, max_evects, hybridization});
 
         // Start at Fine Level
-        Vector rhs_u_fine = upscale.ReadVertexVector(rhs_filename);
+        Vector rhs_u_fine = ReadVertexVector(graph, rhs_filename);
 
         // Do work at Coarse Level
         Vector rhs_u_coarse = upscale.Restrict(rhs_u_fine);
@@ -118,7 +118,7 @@ int main(int argc, char* argv[])
         Vector sol_u_fine = upscale.Interpolate(sol_u_coarse);
         upscale.Orthogonalize(0, sol_u_fine);
 
-        upscale.WriteVertexVector(sol_u_fine, "sol3.out");
+        WriteVertexVector(graph, sol_u_fine, "sol3.out");
     }
 
     // Comparing Error; essentially generalgraph.cpp
@@ -128,7 +128,7 @@ int main(int argc, char* argv[])
 
         GraphUpscale upscale(graph, {spect_tol, max_evects, hybridization});
 
-        BlockVector fine_rhs = upscale.ReadVertexBlockVector(rhs_filename);
+        BlockVector fine_rhs = ReadVertexBlockVector(graph, rhs_filename);
 
         BlockVector fine_sol = upscale.Solve(0, fine_rhs);
         BlockVector upscaled_sol = upscale.Solve(1, fine_rhs);
@@ -156,7 +156,7 @@ int main(int argc, char* argv[])
         GraphUpscale hb_upscale(graph, {spect_tol, max_evects, use_hybridization});
         GraphUpscale minres_upscale(graph, {spect_tol, max_evects, !use_hybridization});
 
-        Vector rhs_u_fine = minres_upscale.ReadVertexVector(rhs_filename);
+        Vector rhs_u_fine = ReadVertexVector(graph, rhs_filename);
 
         Vector minres_sol = minres_upscale.Solve(rhs_u_fine);
         Vector hb_sol = hb_upscale.Solve(rhs_u_fine);

--- a/examples/mlmc.cpp
+++ b/examples/mlmc.cpp
@@ -141,9 +141,9 @@ int main(int argc, char* argv[])
     Graph graph(comm, vertex_edge_global, part, weight);
 
     int sampler_seed = initial_seed + myid;
-    PDESampler sampler(std::move(sampler_graph), spect_tol, max_evects, hybridization,
+    PDESampler sampler(std::move(sampler_graph), {spect_tol, max_evects, hybridization},
                        dimension, kappa, cell_volume, sampler_seed);
-    GraphUpscale upscale(std::move(graph), spect_tol, max_evects, hybridization);
+    GraphUpscale upscale(std::move(graph), {spect_tol, max_evects, hybridization});
 
     /// [Upscale]
 

--- a/examples/mlmc.cpp
+++ b/examples/mlmc.cpp
@@ -141,9 +141,9 @@ int main(int argc, char* argv[])
     Graph graph(comm, vertex_edge_global, part, weight);
 
     int sampler_seed = initial_seed + myid;
-    PDESampler sampler(std::move(sampler_graph), {spect_tol, max_evects, hybridization},
+    PDESampler sampler(sampler_graph, {spect_tol, max_evects, hybridization},
                        dimension, kappa, cell_volume, sampler_seed);
-    GraphUpscale upscale(std::move(graph), {spect_tol, max_evects, hybridization});
+    GraphUpscale upscale(graph, {spect_tol, max_evects, hybridization});
 
     /// [Upscale]
 
@@ -151,7 +151,7 @@ int main(int argc, char* argv[])
     BlockVector fine_rhs = upscale.GetBlockVector(0);
 
     fine_rhs.GetBlock(0) = 0.0;
-    fine_rhs.GetBlock(1) = upscale.ReadVertexVector(fiedler_filename);
+    fine_rhs.GetBlock(1) = ReadVertexVector(graph, fiedler_filename);
     /// [Right Hand Side]
 
     /// [Solve]
@@ -181,10 +181,10 @@ int main(int argc, char* argv[])
 
         if (save_output)
         {
-            SaveOutput(upscale, upscaled_sol.GetBlock(1), "coarse_sol_", i);
-            SaveOutput(upscale, fine_sol.GetBlock(1), "fine_sol_", i);
-            SaveOutput(upscale, upscaled_coeff, "coarse_coeff_", i);
-            SaveOutput(upscale, fine_coeff, "fine_coeff_", i);
+            SaveOutput(graph, upscaled_sol.GetBlock(1), "coarse_sol_", i);
+            SaveOutput(graph, fine_sol.GetBlock(1), "fine_sol_", i);
+            SaveOutput(graph, upscaled_coeff, "coarse_coeff_", i);
+            SaveOutput(graph, fine_coeff, "fine_coeff_", i);
         }
 
         upscale.ShowCoarseSolveInfo();

--- a/examples/poweriter.cpp
+++ b/examples/poweriter.cpp
@@ -62,7 +62,7 @@ int main(int argc, char* argv[])
     std::vector<int> part = PartitionAAT(vertex_edge, coarse_factor);
     Graph graph(comm, vertex_edge, part);
 
-    GraphUpscale upscale(graph, spect_tol, max_evects, hybridization);
+    GraphUpscale upscale(graph, {spect_tol, max_evects, hybridization});
 
     // Wrapper for solving on the fine level, no upscaling
     UpscaleSolveLevel fine_solver(upscale, 0);

--- a/examples/poweriter.cpp
+++ b/examples/poweriter.cpp
@@ -70,7 +70,7 @@ int main(int argc, char* argv[])
     upscale.PrintInfo();
 
     // Read and normalize true Fiedler vector
-    Vector true_sol = upscale.ReadVertexVector(rhs_filename);
+    Vector true_sol = ReadVertexVector(graph, rhs_filename);
     true_sol /= ParL2Norm(comm, true_sol);
 
     // Power Iteration for each Operator

--- a/examples/sampler.cpp
+++ b/examples/sampler.cpp
@@ -149,7 +149,7 @@ int main(int argc, char* argv[])
     Graph graph(comm, vertex_edge_global, part, weight, W_block);
 
     int sampler_seed = initial_seed + myid;
-    PDESampler sampler(std::move(graph), {spect_tol, max_evects, hybridization},
+    PDESampler sampler(graph, {spect_tol, max_evects, hybridization},
                        dimension, kappa, cell_volume, sampler_seed);
     const auto& upscale = sampler.GetUpscale();
 
@@ -211,8 +211,8 @@ int main(int argc, char* argv[])
 
         if (save_output)
         {
-            SaveOutput(upscale, upscaled_sol, "coarse_sol_", sample);
-            SaveOutput(upscale, fine_sol, "fine_sol_", sample);
+            SaveOutput(graph, upscaled_sol, "coarse_sol_", sample);
+            SaveOutput(graph, fine_sol, "fine_sol_", sample);
         }
     }
 
@@ -249,10 +249,10 @@ int main(int argc, char* argv[])
 
     if (save_output)
     {
-        upscale.WriteVertexVector(mean_upscaled, "mean_upscaled.txt");
-        upscale.WriteVertexVector(mean_fine, "mean_fine.txt");
-        upscale.WriteVertexVector(m2_upscaled, "m2_upscaled.txt");
-        upscale.WriteVertexVector(m2_fine, "m2_fine.txt");
+        WriteVertexVector(graph, mean_upscaled, "mean_upscaled.txt");
+        WriteVertexVector(graph, mean_fine, "mean_fine.txt");
+        WriteVertexVector(graph, m2_upscaled, "m2_upscaled.txt");
+        WriteVertexVector(graph, m2_fine, "m2_fine.txt");
     }
 
     return 0;

--- a/examples/sampler.cpp
+++ b/examples/sampler.cpp
@@ -149,7 +149,7 @@ int main(int argc, char* argv[])
     Graph graph(comm, vertex_edge_global, part, weight, W_block);
 
     int sampler_seed = initial_seed + myid;
-    PDESampler sampler(std::move(graph), spect_tol, max_evects, hybridization,
+    PDESampler sampler(std::move(graph), {spect_tol, max_evects, hybridization},
                        dimension, kappa, cell_volume, sampler_seed);
     const auto& upscale = sampler.GetUpscale();
 

--- a/examples/timestep.cpp
+++ b/examples/timestep.cpp
@@ -139,7 +139,7 @@ int main(int argc, char* argv[])
 
     if (!rhs_filename.empty())
     {
-        fine_rhs.GetBlock(1) = upscale.ReadVertexVector(rhs_filename);
+        fine_rhs.GetBlock(1) = ReadVertexVector(graph, rhs_filename);
     }
     else
     {
@@ -161,7 +161,7 @@ int main(int argc, char* argv[])
         std::fill(std::begin(u_half), std::begin(u_half) + half, -1.0);
         std::fill(std::begin(u_half) + half, std::end(u_half), 1.0);
 
-        fine_u.GetBlock(1) = upscale.GetVertexVector(u_half);
+        fine_u.GetBlock(1) = GetVertexVector(graph, u_half);
     }
 
     BlockVector tmp(offsets[k]);
@@ -193,7 +193,7 @@ int main(int argc, char* argv[])
         std::stringstream ss;
         ss << output_dir << std::setw(5) << std::setfill('0') << count << ".txt";
 
-        upscale.WriteVertexVector(fine_u.GetBlock(1), ss.str());
+        WriteVertexVector(graph, fine_u.GetBlock(1), ss.str());
     }
 
     Timer chrono(Timer::Start::True);
@@ -229,7 +229,7 @@ int main(int argc, char* argv[])
             std::stringstream ss;
             ss << output_dir << std::setw(5) << std::setfill('0') << count << ".txt";
 
-            upscale.WriteVertexVector(fine_u.GetBlock(1), ss.str());
+            WriteVertexVector(graph, fine_u.GetBlock(1), ss.str());
         }
 
         chrono.Click();

--- a/examples/timestep.cpp
+++ b/examples/timestep.cpp
@@ -126,7 +126,7 @@ int main(int argc, char* argv[])
 
     /// [Upscale]
     Graph graph(comm, vertex_edge_global, global_partitioning, weight, W_block);
-    GraphUpscale upscale(graph, spect_tol, max_evects, hybridization);
+    GraphUpscale upscale(graph, {spect_tol, max_evects, hybridization});
 
 
     upscale.PrintInfo();

--- a/include/Graph.hpp
+++ b/include/Graph.hpp
@@ -108,6 +108,40 @@ private:
     void MakeLocalW(const SparseMatrix& W_global);
 };
 
+template <typename T>
+T GetVertexVector(const Graph& graph, const T& global_vect)
+{
+    return GetSubVector(global_vect, graph.vertex_map_);
+}
+
+template <typename T>
+void WriteVertexVector(const Graph& graph, const T& vect, const std::string& filename)
+{
+    WriteVector(graph.edge_true_edge_.GetComm(), vect, filename,
+                graph.global_vertices_, graph.vertex_map_);
+}
+
+inline
+Vector ReadVertexVector(const Graph& graph, const std::string& filename)
+{
+    return ReadVector(filename, graph.vertex_map_);
+}
+
+inline
+BlockVector ReadVertexBlockVector(const Graph& graph, const std::string& filename)
+{
+    int num_vertices = graph.vertex_edge_local_.Rows();
+    int num_edges = graph.vertex_edge_local_.Cols();
+
+    BlockVector vect({0, num_edges, num_edges + num_vertices});
+
+    vect.GetBlock(0) = 0.0;
+    vect.GetBlock(1) = ReadVertexVector(graph, filename);
+
+    return vect;
+}
+
+
 } // namespace smoothg
 
 #endif /* __GRAPH_HPP__ */

--- a/include/GraphCoarsen.hpp
+++ b/include/GraphCoarsen.hpp
@@ -214,6 +214,7 @@ private:
     std::vector<int> GetExtDofs(const ParMatrix& mat_ext, int row) const;
 
     ParMatrix MakeExtPermutation(const ParMatrix& parmat) const;
+    int ComputeEdgeNNZ() const;
 
     void DebugChecks(const MixedMatrix& mgl) const;
 

--- a/src/GraphCoarsen.cpp
+++ b/src/GraphCoarsen.cpp
@@ -162,12 +162,10 @@ void GraphCoarsen::ComputeVertexTargets(const ParMatrix& M_ext_global,
 
     int num_aggs = gt_.NumAggs();
 
-    DenseMatrix evects;
     LocalEigenSolver eigs(max_evects_, spect_tol_);
 
+    DenseMatrix evects;
     DenseMatrix DT_evect;
-
-    bool is_diag = IsDiag(M_ext);
 
     for (int agg = 0; agg < num_aggs; ++agg)
     {
@@ -189,29 +187,10 @@ void GraphCoarsen::ComputeVertexTargets(const ParMatrix& M_ext_global,
 
         if (evects.Cols() > 1)
         {
-               DenseMatrix evects_ortho = evects.GetCol(1, evects.Cols());
+            SparseSolver M_inv(std::move(M_sub));
 
-               DT_evect.SetSize(D_sub.Cols(), evects_ortho.Cols());
-               D_sub.MultAT(evects_ortho, DT_evect);
-
-               DenseMatrix MinvDT_evect(DT_evect.Rows(), DT_evect.Cols());
-
-               if (is_diag)
-               {
-                   MinvDT_evect = DT_evect;
-                   MinvDT_evect.InverseScaleRows(M_sub.GetData());
-               }
-               else
-               {
-                   SparseSolver Minv(M_sub);
-                   OffsetMult(Minv, DT_evect, MinvDT_evect, 0);
-               }
-
-               agg_ext_sigma_[agg] = std::move(MinvDT_evect);
-        }
-        else
-        {
-            agg_ext_sigma_[agg].SetSize(M_sub.Rows(), 0);
+            OffsetMultAT(D_sub, evects, DT_evect, 1);
+            OffsetMult(M_inv, DT_evect, agg_ext_sigma_[agg], 0);
         }
 
         DenseMatrix evects_restricted = RestrictLocal(evects, col_marker_,
@@ -375,7 +354,6 @@ void GraphCoarsen::ComputeEdgeTargets(const MixedMatrix& mgl,
 
         if (!sec_face.IsOwnedByMe(face))
         {
-            edge_targets_[face].SetSize(num_face_edges, 0);
             continue;
         }
 
@@ -394,10 +372,10 @@ void GraphCoarsen::ComputeEdgeTargets(const MixedMatrix& mgl,
 
         bool shared = face_shared.RowSize(face) > 0;
 
+        int split = shared ? face_D[0].Rows() : GetSplit(face);
         SparseMatrix M_local = shared ? CombineM(face_M, num_face_edges) : std::move(face_M[0]);
         SparseMatrix D_local = shared ? CombineD(face_D, num_face_edges) : std::move(face_D[0]);
-        const auto& constant_local = shared ? CombineConstant(face_constant) : face_constant[0];
-        const int split = shared ? face_D[0].Rows() : GetSplit(face);
+        Vector constant_local = shared ? CombineConstant(face_constant) : std::move(face_constant[0]);
 
 
         GraphEdgeSolver solver(std::move(M_local), std::move(D_local));
@@ -754,30 +732,26 @@ void GraphCoarsen::BuildPvertex()
                              num_vertexdofs , coarse_dof_counter);
 }
 
-int ComputeNNZ(const GraphTopology& gt, const SparseMatrix& agg_bubble_dof,
-               const SparseMatrix& face_cdof)
+int GraphCoarsen::ComputeEdgeNNZ() const
 {
-    const SparseMatrix& agg_face = gt.agg_face_local_;
-    //const SparseMatrix& agg_edge = agg_edgedof_;
-    //const SparseMatrix& face_edge = face_edgedof_;
-    // TODO(gelever1): This is wrong cus dofs not considered
-    const SparseMatrix& agg_edge = gt.agg_edge_local_;
-    const SparseMatrix& face_edge = gt.face_edge_local_;
+    const SparseMatrix& agg_face = gt_.agg_face_local_;
+    const SparseMatrix& agg_edge = agg_edgedof_;
+    const SparseMatrix& face_edge = face_edgedof_;
 
-    int num_aggs = gt.NumAggs();
-    int num_faces = gt.NumFaces();
+    int num_aggs = gt_.NumAggs();
+    int num_faces = gt_.NumFaces();
 
     int nnz = 0;
     for (int agg = 0; agg < num_aggs; ++agg)
     {
         int edge_dofs = agg_edge.RowSize(agg);
-        int bubble_dofs = agg_bubble_dof.RowSize(agg);
+        int bubble_dofs = agg_bubble_dof_.RowSize(agg);
 
         std::vector<int> faces = agg_face.GetIndices(agg);
 
         for (auto face : faces)
         {
-            int face_coarse_dofs = face_cdof.RowSize(face);
+            int face_coarse_dofs = face_cdof_.RowSize(face);
             nnz += edge_dofs * face_coarse_dofs;
         }
 
@@ -787,7 +761,7 @@ int ComputeNNZ(const GraphTopology& gt, const SparseMatrix& agg_bubble_dof,
     for (int face = 0; face < num_faces; ++face)
     {
         int face_fine_dofs = face_edge.RowSize(face);
-        int face_coarse_dofs = face_cdof.RowSize(face);
+        int face_coarse_dofs = face_cdof_.RowSize(face);
 
         nnz += face_fine_dofs * face_coarse_dofs;
     }
@@ -808,7 +782,7 @@ void GraphCoarsen::BuildPedge(const MixedMatrix& mgl)
     int num_coarse_dofs = agg_bubble_dof_.Cols();
 
     CooMatrix P_edge(num_edgedofs, num_coarse_dofs);
-    P_edge.Reserve(ComputeNNZ(gt_, agg_bubble_dof_, face_cdof_));
+    P_edge.Reserve(ComputeEdgeNNZ());
 
     DenseMatrix bubbles;
     DenseMatrix trace_ext;
@@ -885,7 +859,7 @@ void GraphCoarsen::BuildQedge(const MixedMatrix& mgl)
     int num_coarse_dofs = agg_bubble_dof_.Cols();
 
     CooMatrix Q_edge(num_edgedofs, num_coarse_dofs);
-    Q_edge.Reserve(ComputeNNZ(gt_, agg_bubble_dof_, face_cdof_));
+    Q_edge.Reserve(ComputeEdgeNNZ());
 
     DenseMatrix Q_i;
 

--- a/src/GraphCoarsen.cpp
+++ b/src/GraphCoarsen.cpp
@@ -622,12 +622,11 @@ Vector GraphCoarsen::MakeOneNegOne(const Vector& constant, int split) const
         v2_sum += constant[i] * constant[i];
     }
 
-    double c1 = 1.0 / split;
-    double c2 = -c1 * (v1_sum / v2_sum);
+    double c2 = -1.0 * (v1_sum / v2_sum);
 
     for (int i = 0; i < split; ++i)
     {
-        vect[i] = c1 * constant[i];
+        vect[i] = constant[i];
     }
 
     for (int i = split; i < size; ++i)

--- a/src/GraphUpscale.cpp
+++ b/src/GraphUpscale.cpp
@@ -23,7 +23,7 @@
 namespace smoothg
 {
 
-GraphUpscale::GraphUpscale(Graph graph, const UpscaleParams& params)
+GraphUpscale::GraphUpscale(const Graph& graph, const UpscaleParams& params)
     : Operator(graph.vertex_edge_local_.Rows()),
       mgl_(params.max_levels),
       coarsener_(params.max_levels - 1),
@@ -34,17 +34,14 @@ GraphUpscale::GraphUpscale(Graph graph, const UpscaleParams& params)
       elim_dofs_(params.max_levels),
       comm_(graph.edge_true_edge_.GetComm()),
       myid_(graph.edge_true_edge_.GetMyId()),
-      global_vertices_(graph.global_vertices_),
-      global_edges_(graph.global_edges_),
       setup_time_(0),
-      hybridization_(params.hybridization),
-      graph_(std::move(graph))
+      hybridization_(params.hybridization)
 {
     Timer timer(Timer::Start::True);
 
     // Compute Topology
     std::vector<GraphTopology> gts;
-    gts.emplace_back(graph_);
+    gts.emplace_back(graph);
 
     for (int level = 1; level < params.max_levels - 1; ++level)
     {
@@ -54,7 +51,7 @@ GraphUpscale::GraphUpscale(Graph graph, const UpscaleParams& params)
     // Fine Level
     int level = 0;
     {
-        mgl_[level] = MixedMatrix(graph_);
+        mgl_[level] = MixedMatrix(graph);
         mgl_[level].AssembleM();
 
         elim_dofs_[level] = params.elim_edge_dofs;
@@ -65,16 +62,19 @@ GraphUpscale::GraphUpscale(Graph graph, const UpscaleParams& params)
     // Coarse Levels
     for (level = 1; level < params.max_levels; ++level)
     {
-        double spect_tol_i = params.spectral_tol[level - 1].first;
-        int num_evects_i = params.spectral_tol[level - 1].second;
+        auto& gt_i = gts[level - 1];
+        auto& spect_pair_i = params.spectral_pair[level - 1];
 
-        int num_vert = gts[level - 1].GlobalNumVertices();
-        int num_agg = gts[level - 1].GlobalNumAggs();
+        double spect_tol_i = spect_pair_i.first;
+        int num_evects_i = spect_pair_i.second;
+
+        int num_vert = gt_i.GlobalNumVertices();
+        int num_agg = gt_i.GlobalNumAggs();
 
         ParPrint(myid_, printf("Coarsening: %d / %d = %.2f, evects: %d\n",
                  num_vert, num_agg, num_vert / (double) num_agg, num_evects_i));
 
-        coarsener_[level - 1] = GraphCoarsen(std::move(gts[level - 1]), mgl_[level - 1],
+        coarsener_[level - 1] = GraphCoarsen(std::move(gt_i), mgl_[level - 1],
                                              num_evects_i, spect_tol_i);
         mgl_[level] = MixedMatrix(coarsener_[level - 1].Coarsen(mgl_[level - 1]));
         mgl_[level].AssembleM();
@@ -133,21 +133,6 @@ void GraphUpscale::MakeSolver(int level, const std::vector<double>& agg_weights)
     }
 }
 
-Vector GraphUpscale::ReadVertexVector(const std::string& filename) const
-{
-    return ReadVector(filename, graph_.vertex_map_);
-}
-
-BlockVector GraphUpscale::ReadVertexBlockVector(const std::string& filename) const
-{
-    BlockVector vect = GetBlockVector(0);
-
-    vect.GetBlock(0) = 0.0;
-    vect.GetBlock(1) = ReadVertexVector(filename);
-
-    return vect;
-}
-
 std::vector<BlockVector> GraphUpscale::MultMultiLevel(const BlockVector& x) const
 {
     std::vector<BlockVector> sols;
@@ -199,13 +184,7 @@ void GraphUpscale::MultMultiGrid(const BlockVector& x, BlockVector& sol) const
         rhs_[i].GetBlock(1) *= -1.0;
         sol_[i].GetBlock(1) *= -1.0;
 
-        //int max_iter = (i == 0) ? 5000 : std::pow(2.0, i + 3);
-        //solver_[i]->SetMaxIter(max_iter);
-        //ParPrint(MyId(), printf("Level %d Max Iter: %d\n", i, max_iter));
-
         solver_[i]->Solve(rhs_[i], sol_[i]);
-
-        //solver_[i]->SetMaxIter(5000);
 
         if (do_ortho_)
         {
@@ -634,11 +613,11 @@ double GraphUpscale::OperatorComplexity() const
 {
     assert(solver_[1]);
 
-    double nnz_coarse = 0.0;
+    double nnz_levels = 0.0;
 
     for (auto&& solver : solver_)
     {
-        nnz_coarse += solver->GetNNZ();
+        nnz_levels += solver->GetNNZ();
     }
 
     double nnz_fine;
@@ -652,9 +631,7 @@ double GraphUpscale::OperatorComplexity() const
         nnz_fine = GetMatrix(0).GlobalNNZ();
     }
 
-    double op_comp = nnz_coarse / nnz_fine;
-
-    return op_comp;
+    return nnz_levels / nnz_fine;
 }
 
 void GraphUpscale::SetPrintLevel(int print_level)

--- a/src/GraphUpscale.cpp
+++ b/src/GraphUpscale.cpp
@@ -23,38 +23,32 @@
 namespace smoothg
 {
 
-GraphUpscale::GraphUpscale(Graph graph, double spect_tol, int max_evects, bool hybridization,
-                           int num_levels, const std::vector<int>& edge_elim_dofs)
+GraphUpscale::GraphUpscale(Graph graph, const UpscaleParams& params)
     : Operator(graph.vertex_edge_local_.Rows()),
-      mgl_(num_levels),
-      coarsener_(num_levels - 1),
-      solver_(num_levels),
-      rhs_(num_levels),
-      sol_(num_levels),
-      constant_rep_(num_levels),
-      elim_dofs_(num_levels),
+      mgl_(params.max_levels),
+      coarsener_(params.max_levels - 1),
+      solver_(params.max_levels),
+      rhs_(params.max_levels),
+      sol_(params.max_levels),
+      constant_rep_(params.max_levels),
+      elim_dofs_(params.max_levels),
       comm_(graph.edge_true_edge_.GetComm()),
       myid_(graph.edge_true_edge_.GetMyId()),
       global_vertices_(graph.global_vertices_),
       global_edges_(graph.global_edges_),
       setup_time_(0),
-      spect_tol_(spect_tol), max_evects_(max_evects),
-      hybridization_(hybridization),
+      hybridization_(params.hybridization),
       graph_(std::move(graph))
 {
     Timer timer(Timer::Start::True);
 
     // Compute Topology
-    double coarsen_factor = 4.0;
-    //double coarsen_factor = 8.0;
-    //double coarsen_factor = 16.0;
-
     std::vector<GraphTopology> gts;
     gts.emplace_back(graph_);
 
-    for (int level = 1; level < num_levels - 1; ++level)
+    for (int level = 1; level < params.max_levels - 1; ++level)
     {
-        gts.emplace_back(gts.back(), coarsen_factor);
+        gts.emplace_back(gts.back(), params.coarsen_factor);
     }
 
     // Fine Level
@@ -63,24 +57,25 @@ GraphUpscale::GraphUpscale(Graph graph, double spect_tol, int max_evects, bool h
         mgl_[level] = MixedMatrix(graph_);
         mgl_[level].AssembleM();
 
-        elim_dofs_[level] = edge_elim_dofs;
+        elim_dofs_[level] = params.elim_edge_dofs;
         MakeSolver(level);
         MakeVectors(level);
     }
 
     // Coarse Levels
-    for (level = 1; level < num_levels; ++level)
+    for (level = 1; level < params.max_levels; ++level)
     {
-        //int num_evects = max_evects + level - 1;
-        int num_evects = max_evects;
+        double spect_tol_i = params.spectral_tol[level - 1].first;
+        int num_evects_i = params.spectral_tol[level - 1].second;
+
         int num_vert = gts[level - 1].GlobalNumVertices();
         int num_agg = gts[level - 1].GlobalNumAggs();
 
         ParPrint(myid_, printf("Coarsening: %d / %d = %.2f, evects: %d\n",
-                 num_vert, num_agg, num_vert / (double) num_agg, num_evects));
+                 num_vert, num_agg, num_vert / (double) num_agg, num_evects_i));
 
         coarsener_[level - 1] = GraphCoarsen(std::move(gts[level - 1]), mgl_[level - 1],
-                                             num_evects, spect_tol_);
+                                             num_evects_i, spect_tol_i);
         mgl_[level] = MixedMatrix(coarsener_[level - 1].Coarsen(mgl_[level - 1]));
         mgl_[level].AssembleM();
 

--- a/testcode/test_projection.cpp
+++ b/testcode/test_projection.cpp
@@ -61,7 +61,7 @@ int main(int argc, char* argv[])
     // Set up GraphUpscale
     /// [Upscale]
     Graph graph(comm, vertex_edge_global, global_partitioning);
-    GraphUpscale upscale(std::move(graph), {spect_tol, max_evects});
+    GraphUpscale upscale(graph, {spect_tol, max_evects});
 
     upscale.PrintInfo();
     upscale.ShowSetupTime();

--- a/testcode/test_projection.cpp
+++ b/testcode/test_projection.cpp
@@ -61,7 +61,7 @@ int main(int argc, char* argv[])
     // Set up GraphUpscale
     /// [Upscale]
     Graph graph(comm, vertex_edge_global, global_partitioning);
-    GraphUpscale upscale(std::move(graph), spect_tol, max_evects);
+    GraphUpscale upscale(std::move(graph), {spect_tol, max_evects});
 
     upscale.PrintInfo();
     upscale.ShowSetupTime();


### PR DESCRIPTION
* Collects all upscaling parameters into on struct.  W/ minimal changes to example/driver programs.
* Adds option to set spectral tolerance and max evects per coarsening step.
* Remove `Graph` member from `GraphUpscale`.  Read/Write global vertex vectors handled by `Graph` now.  `GraphUpscale` now handles only the upscaling related operations.