### PR TITLE
Add utility functions for external mixed matrices

### DIFF
--- a/examples/generalgraph.cpp
+++ b/examples/generalgraph.cpp
@@ -169,7 +169,6 @@ int main(int argc, char* argv[])
     {
         fine_rhs.GetBlock(1) = ReadVertexVector(graph, fiedler_filename);
     }
-
     /// [Right Hand Side]
 
     /// [Solve and Check Error]

--- a/examples/mlmc.cpp
+++ b/examples/mlmc.cpp
@@ -170,8 +170,8 @@ int main(int argc, char* argv[])
         const auto& coarse_coeff = sampler.GetCoefficientCoarse();
         const auto& upscaled_coeff = sampler.GetCoefficientUpscaled();
 
-        upscale.MakeSolver(1, coarse_coeff);
-        upscale.MakeSolver(0, fine_coeff);
+        upscale.RescaleSolver(1, coarse_coeff);
+        upscale.RescaleSolver(0, fine_coeff);
 
         fine_sol = 0.0;
         upscaled_sol = 0.0;

--- a/include/GraphUpscale.hpp
+++ b/include/GraphUpscale.hpp
@@ -107,11 +107,14 @@ public:
     /// Get global number of columns (vertex dofs)
     int GlobalCols() const;
 
-    /// Create Weighted Solver
+    /// Create Solver
     void MakeSolver(int level);
+    void MakeSolver(int level, MixedMatrix& mm);
 
-    /// Create Weighted Solver
-    void MakeSolver(int level, const std::vector<double>& agg_weights);
+    /// Rescale solver w/ weights per aggregate
+    void RescaleSolver(int level, const std::vector<double>& agg_weights);
+    void RescaleSolver(int level, const std::vector<double>& agg_weights,
+                    MixedMatrix& mm);
 
     /// Wrapper for applying the upscaling, in linalgcpp terminology
     void Mult(const VectorView& x, VectorView y) const override;
@@ -250,6 +253,15 @@ public:
                     const BlockVector& fine_sol) const;
 
     ParMatrix ToPrimal() const;
+
+    /// Set orthogonalization against constant of vertex solution after solving
+    void SetOrthogonalize(bool do_ortho = true) { do_ortho_ = do_ortho; }
+
+    /// Check use of hybridizaiton solver
+    bool Hybridization() const { return hybridization_; }
+
+    /// Check use of orthogonalization
+    bool Orthogonalization() const { return do_ortho_; }
 
 private:
     std::vector<Level> levels_;

--- a/include/HybridSolver.hpp
+++ b/include/HybridSolver.hpp
@@ -139,6 +139,7 @@ private:
                             std::vector<int>& edge_map,
                             std::vector<bool>& edge_marker) const;
 
+    void CountEdgeDofs();
     void InitSolver(SparseMatrix local_hybrid);
 
     ParMatrix ComputeScaledSystem(const ParMatrix& hybrid_d);
@@ -158,6 +159,7 @@ private:
     linalgcpp::PCGSolver cg_;
     parlinalgcpp::BoomerAMG prec_;
 
+    std::vector<DenseMatrix> Minv_;
     std::vector<DenseMatrix> MinvDT_;
     std::vector<DenseMatrix> MinvCT_;
     std::vector<DenseMatrix> AinvDMinvCT_;
@@ -165,7 +167,10 @@ private:
     std::vector<DenseMatrix> hybrid_elem_;
 
     mutable std::vector<Vector> Ainv_f_;
+    mutable std::vector<Vector> Minv_g_;
+    mutable std::vector<Vector> AinvDMinv_g_;
 
+    std::vector<int> edgedof_count_;
     std::vector<double> agg_weights_;
 
     mutable Vector trueHrhs_;

--- a/include/SPDSolver.hpp
+++ b/include/SPDSolver.hpp
@@ -98,8 +98,13 @@ public:
     virtual void SetAbsTol(double atol) override;
     ///@}
 
+    const ParMatrix& A() const { return A_; }
+    const ParMatrix& Minv() const { return Minv_; }
+    const ParMatrix& MinvDT() const { return MinvDT_; }
+
 protected:
     ParMatrix A_;
+    ParMatrix Minv_;
     ParMatrix MinvDT_;
 
 private:

--- a/src/GraphCoarsen.cpp
+++ b/src/GraphCoarsen.cpp
@@ -429,7 +429,6 @@ void GraphCoarsen::ScaleEdgeTargets(const MixedMatrix& mgl, const VectorView& co
 
         constant_vect.GetSubVector(vertices, one);
 
-        oneD.SetSize(D_transfer.Cols());
         D_transfer.MultAT(one, oneD);
 
         VectorView pv_trace = edge_traces.GetColView(0);
@@ -822,9 +821,6 @@ void GraphCoarsen::BuildPedge(const MixedMatrix& mgl, const VectorView& constant
             SparseMatrix M_transfer = mgl.LocalM().GetSubMatrix(edge_dofs, face_fine_dofs, col_marker_);
             SparseMatrix D_transfer = mgl.LocalD().GetSubMatrix(vertex_dofs, face_fine_dofs, col_marker_);
 
-            M_trace.SetSize(M_transfer.Rows(), edge_targets_[face].Cols());
-            D_trace.SetSize(D_transfer.Rows(), edge_targets_[face].Cols());
-
             M_transfer.Mult(edge_targets_[face], M_trace);
             D_transfer.Mult(edge_targets_[face], D_trace);
 
@@ -915,8 +911,6 @@ void GraphCoarsen::BuildQedge(const MixedMatrix& mgl, const VectorView& constant
         constant_vect.GetSubVector(vertex_dofs, one_rep);
 
         SparseMatrix D_transfer = mgl.LocalD().GetSubMatrix(vertex_dofs, face_fine_dofs, col_marker_);
-
-        one_D.SetSize(D_transfer.Cols());
         D_transfer.MultAT(one_rep, one_D);
 
         double one_D_PV = one_D.Mult(PV_trace);
@@ -931,7 +925,6 @@ void GraphCoarsen::BuildQedge(const MixedMatrix& mgl, const VectorView& constant
         {
             trace.GetCol(1, trace.Cols(), sigma_f);
 
-            sigma_f_PV.SetSize(sigma_f.Cols());
             sigma_f.MultAT(PV_trace, sigma_f_PV);
             OuterProduct(one_D, sigma_f_PV, DT_one_sigma_f_PV);
             DT_one_sigma_f_PV /= one_D_PV;
@@ -1177,9 +1170,6 @@ std::vector<DenseMatrix> GraphCoarsen::BuildElemM(const MixedMatrix& mgl,
         auto cdofs = agg_cdof_edge.GetIndices(i);
 
         GetSubMatrix(P_edge_, agg_dofs, cdofs, col_marker_, P_sub);
-
-        M_tmp.SetSize(P_sub.Cols(), M_loc.Cols());
-        M_elem[i].SetSize(P_sub.Cols(), P_sub.Cols());
 
         M_loc.Mult(P_sub, M_tmp);
         P_sub.MultAT(M_tmp, M_elem[i]);

--- a/src/HybridSolver.cpp
+++ b/src/HybridSolver.cpp
@@ -409,12 +409,14 @@ void HybridSolver::RHSTransform(const BlockVector& OriginalRHS,
 
         CMinv_g_loc.SetSize(nlocal_multiplier);
         MinvCT_[iAgg].MultAT(g_loc, CMinv_g_loc);
+        CMinv_g_loc *= agg_weights_[iAgg];
 
         DMinv_g_loc.SetSize(nlocal_vertexdof);
         MinvDT_[iAgg].MultAT(g_loc, DMinv_g_loc);
 
         CMinvDTAinvDM_g_loc.SetSize(nlocal_multiplier);
         AinvDMinvCT_[iAgg].MultAT(DMinv_g_loc, CMinvDTAinvDM_g_loc);
+        CMinvDTAinvDM_g_loc *= agg_weights_[iAgg];
 
         CMinvDTAinv_f_loc -= CMinvDTAinvDM_g_loc;
         CMinvDTAinv_f_loc += CMinv_g_loc;

--- a/src/HybridSolver.cpp
+++ b/src/HybridSolver.cpp
@@ -32,12 +32,16 @@ HybridSolver::HybridSolver(const MixedMatrix& mgl, const GraphSpace& graph_space
     num_aggs_(agg_edgedof_.Rows()),
     num_edge_dofs_(agg_edgedof_.Cols()),
     num_multiplier_dofs_(graph_space.face_facedof.Cols()),
-    MinvDT_(num_aggs_), MinvCT_(num_aggs_),
+    Minv_(num_aggs_), MinvDT_(num_aggs_), MinvCT_(num_aggs_),
     AinvDMinvCT_(num_aggs_), Ainv_(num_aggs_),
     hybrid_elem_(num_aggs_), Ainv_f_(num_aggs_),
+    Minv_g_(num_aggs_), AinvDMinv_g_(num_aggs_),
+    edgedof_count_(agg_edgedof_.Cols(), 0.0),
     agg_weights_(num_aggs_, 1.0),
     rescale_iter_(0)
 {
+    CountEdgeDofs();
+
     SparseMatrix edgedof_multiplier = MakeEdgeDofMultiplier();
     SparseMatrix multiplier_edgedof = edgedof_multiplier.Transpose();
     const std::vector<int>& j_multiplier_edgedof = multiplier_edgedof.GetIndices();
@@ -149,6 +153,19 @@ SparseMatrix HybridSolver::MakeEdgeDofMultiplier() const
                         num_edge_dofs_, num_multiplier_dofs_);
 }
 
+void HybridSolver::CountEdgeDofs()
+{
+    for (int i = 0; i < num_aggs_; ++i)
+    {
+        std::vector<int> edgedofs = agg_edgedof_.GetIndices(i);
+
+        for (auto&& dof : edgedofs)
+        {
+            edgedof_count_[dof]++;
+        }
+    }
+}
+
 SparseMatrix HybridSolver::MakeLocalC(int agg, const ParMatrix& edge_true_edge,
                                       const std::vector<int>& j_multiplier_edgedof,
                                       std::vector<int>& edge_map,
@@ -205,8 +222,6 @@ SparseMatrix HybridSolver::AssembleHybridSystem(
     std::vector<int> edge_map(map_size, -1);
     std::vector<bool> edge_marker(num_edge_dofs_, true);
 
-    DenseMatrix Minv;
-
     DenseMatrix Aloc;
     DenseMatrix Wloc;
     DenseMatrix CMDADMC;
@@ -239,13 +254,15 @@ SparseMatrix HybridSolver::AssembleHybridSystem(
         //      CMinvDTAinvDMinvCT = CMinvDT * AinvDMinvCT_
         //      hybrid_elem = CMinvCT - CMinvDTAinvDMinvCT
 
-        M_el[agg].Invert(Minv);
 
+        DenseMatrix& Minv(Minv_[agg]);
         DenseMatrix& MinvCT_i(MinvCT_[agg]);
         DenseMatrix& MinvDT_i(MinvDT_[agg]);
         DenseMatrix& AinvDMinvCT_i(AinvDMinvCT_[agg]);
         DenseMatrix& Ainv_i(Ainv_[agg]);
         DenseMatrix& hybrid_elem(hybrid_elem_[agg]);
+
+        M_el[agg].Invert(Minv);
 
         AinvDMinvCT_i.SetSize(nlocal_vertexdof, nlocal_multiplier);
         hybrid_elem.SetSize(nlocal_multiplier, nlocal_multiplier);
@@ -355,23 +372,52 @@ void HybridSolver::RHSTransform(const BlockVector& OriginalRHS,
     HybridRHS = 0.;
 
     Vector f_loc;
+    Vector g_loc;
     Vector CMinvDTAinv_f_loc;
+    Vector CMinvDTAinvDM_g_loc;
+    Vector CMinv_g_loc;
+    Vector DMinv_g_loc;
 
     for (int iAgg = 0; iAgg < num_aggs_; ++iAgg)
     {
         // Extracting the size and global numbering of local dof
+        std::vector<int> local_edgedof = agg_edgedof_.GetIndices(iAgg);
         std::vector<int> local_vertexdof = agg_vertexdof_.GetIndices(iAgg);
         std::vector<int> local_multiplier = agg_multiplier_.GetIndices(iAgg);
 
+        int nlocal_edgedof = local_edgedof.size();
         int nlocal_vertexdof = local_vertexdof.size();
         int nlocal_multiplier = local_multiplier.size();
 
         // Compute local contribution to the RHS of the hybrid system
+        OriginalRHS.GetBlock(0).GetSubVector(local_edgedof, g_loc);
         OriginalRHS.GetBlock(1).GetSubVector(local_vertexdof, f_loc);
+
+        g_loc *= -1.0;
         f_loc *= -1.0;
+
+        for (int i = 0; i < nlocal_edgedof; ++i)
+        {
+            int count = edgedof_count_[local_edgedof[i]];
+            g_loc[i] /= count;
+
+            assert(count == 1 || count == 2);
+        }
 
         CMinvDTAinv_f_loc.SetSize(nlocal_multiplier);
         AinvDMinvCT_[iAgg].MultAT(f_loc, CMinvDTAinv_f_loc);
+
+        CMinv_g_loc.SetSize(nlocal_multiplier);
+        MinvCT_[iAgg].MultAT(g_loc, CMinv_g_loc);
+
+        DMinv_g_loc.SetSize(nlocal_vertexdof);
+        MinvDT_[iAgg].MultAT(g_loc, DMinv_g_loc);
+
+        CMinvDTAinvDM_g_loc.SetSize(nlocal_multiplier);
+        AinvDMinvCT_[iAgg].MultAT(DMinv_g_loc, CMinvDTAinvDM_g_loc);
+
+        CMinvDTAinv_f_loc -= CMinvDTAinvDM_g_loc;
+        CMinvDTAinv_f_loc += CMinv_g_loc;
 
         for (int i = 0; i < nlocal_multiplier; ++i)
         {
@@ -382,6 +428,13 @@ void HybridSolver::RHSTransform(const BlockVector& OriginalRHS,
         Ainv_f_[iAgg].SetSize(nlocal_vertexdof);
         Ainv_[iAgg].Mult(f_loc, Ainv_f_[iAgg]);
         Ainv_f_[iAgg] /= agg_weights_[iAgg];
+
+
+        AinvDMinv_g_[iAgg].SetSize(nlocal_vertexdof);
+        Ainv_[iAgg].Mult(DMinv_g_loc, AinvDMinv_g_[iAgg]);
+
+        Minv_g_[iAgg].SetSize(nlocal_edgedof);
+        Minv_[iAgg].Mult(g_loc, Minv_g_[iAgg]);
     }
 }
 
@@ -425,6 +478,7 @@ void HybridSolver::RecoverOriginalSolution(const VectorView& HybridSol,
             tmp.SetSize(u_loc.size());
             AinvDMinvCT_[iAgg].Mult(mu_loc, tmp);
             u_loc -= tmp;
+            u_loc -= AinvDMinv_g_[iAgg];
 
             // Compute -sigma = Minv(DT u + DT mu)
             sigma_loc.SetSize(nlocal_edgedof);
@@ -433,6 +487,7 @@ void HybridSolver::RecoverOriginalSolution(const VectorView& HybridSol,
             tmp.SetSize(sigma_loc.size());
             MinvCT_[iAgg].Mult(mu_loc, tmp);
             sigma_loc += tmp;
+            sigma_loc += Minv_g_[iAgg];
             sigma_loc *= agg_weights_[iAgg];
         }
 
@@ -444,7 +499,7 @@ void HybridSolver::RecoverOriginalSolution(const VectorView& HybridSol,
 
         for (int i = 0; i < nlocal_vertexdof; ++i)
         {
-            RecoveredSol.GetBlock(1)[local_vertexdof[i]] = u_loc[i];
+            RecoveredSol.GetBlock(1)[local_vertexdof[i]] += u_loc[i];
         }
     }
 }

--- a/src/Utilities.cpp
+++ b/src/Utilities.cpp
@@ -42,7 +42,7 @@ ParMatrix MakeEdgeTrueEdge(MPI_Comm comm, const SparseMatrix& proc_edge,
     MPI_Comm_size(comm, &num_procs);
     MPI_Comm_rank(comm, &myid);
 
-    auto edge_proc = proc_edge.Transpose();
+    SparseMatrix edge_proc = proc_edge.Transpose();
 
     int num_edges_local = proc_edge.RowSize(myid);
     int num_tedges_global = proc_edge.Cols();

--- a/src/Utilities.cpp
+++ b/src/Utilities.cpp
@@ -480,7 +480,6 @@ double DivError(MPI_Comm comm, const SparseMatrix& D, const VectorView& numer,
 
     const double error = parlinalgcpp::ParL2Norm(comm, Ddiff) /
                          parlinalgcpp::ParL2Norm(comm, Dfine);
-
     return error;
 }
 
@@ -573,7 +572,7 @@ void PrintJSON(const std::map<std::string, double>& values, std::ostream& out,
 
 double Density(const SparseMatrix& A)
 {
-    long long denom = A.Rows() * (long) A.Cols();
+    double denom = A.Rows() * (double) A.Cols();
     return A.nnz() / denom;
 }
 
@@ -596,7 +595,7 @@ SparseMatrix MakeProcAgg(MPI_Comm comm, const SparseMatrix& agg_vertex, const Sp
     // Metis doesn't behave well w/ very dense sparse partition
     // so we partition by hand if aggregates are densely connected
     const double density = Density(agg_agg);
-    const double density_tol = 0.8;
+    const double density_tol = 0.80;
 
     std::vector<int> partition;
 
@@ -811,8 +810,11 @@ std::vector<int> PartitionPostIsolate(const SparseMatrix& A, std::vector<int> pa
 
     for (auto&& vertex : isolated_vertices)
     {
-        partition.at(vertex) = num_parts++;
+        //partition.at(vertex) = num_parts++;
+        partition.at(vertex) = num_parts;
     }
+
+    num_parts++;
 
     std::vector<int> component(num_vertices, -1);
     std::vector<int> offset_comp(num_parts + 1, 0);


### PR DESCRIPTION
Add ability to make solver from external, modified mixed matrix.
Add general block right hand solve to all solvers.

These functions are enough to support Dirichlet boundary conditions:

---
## Example problem on spe10 slice 0:
![blockmatrix](https://user-images.githubusercontent.com/13111488/45241377-2250ce80-b2a1-11e8-9e41-b0205dad7fa1.png)

### Boundary Type 0
Boundary on far side set to 1.0 and 0.0 on close side, right hand side set to 0 elsewhere:
![dirichlet_spe10_2d_slice2](https://user-images.githubusercontent.com/13111488/45235029-62f21d00-b28c-11e8-8700-194a97e5bd25.png)

```sh
mpirun -np 8 ./dirichlet  -nr 1 -cf 0.4 -nl 4 -m 4  -t 1.0 -hb --dim 2 -vis --ml-factor 4 -bt 0 -bv 1
Options used:
   --perm spe_perm.dat
   --dim 2
   --slice 0
   --max-evects 4
   --spect-tol 1
   --no-metis-agglomeration
   --part-unbalance 2
   --spe10-scale 5
   --hybridization
   --no-dual-target
   --no-scaled-dual
   --no-energy-dual
   --visualization
   --num-refine 1
   --coarse-factor 0.4
   --num-levels 4
   --ml-factor 4
   --boundary-type 0
   --boundary-value 1
Permeability file read in 2.0376.s 
Permeability field distributed in 0.0473831.s 
13370 fine edges, 0 fine faces, 6600 fine elements

GraphUpscale Setup Time:      1.55547

Processors: 8
---------------------

Level 0 Matrix
---------------------
M Size          106160
D Size          52800
+ Size          158960
NonZeros:       528560

Level 1 Matrix
---------------------
M Size          7744
D Size          2912
+ Size          10656
NonZeros:       232672

Op Comp:        1.57

Level 2 Matrix
---------------------
M Size          2376
D Size          736
+ Size          3112
NonZeros:       95464

Op Comp:        1.26

Level 3 Matrix
---------------------
M Size          568
D Size          192
+ Size          760
NonZeros:       21112

Op Comp:        1.06


Fine Solve Time:         2.34556
Fine Solve Iterations:   18

Level 1 Solve Time:       0.640513
Level 1 Solve Iterations: 243

Level 2 Solve Time:       0.0267823
Level 2 Solve Iterations: 159

Level 3 Solve Time:       0.00801627
Level 3 Solve Iterations: 122
Solution Level 1
{
  "finest-div-error": 0.06096745726624386,
  "finest-p-error": 0.009427200742786889,
  "finest-u-error": 0.07793348003343316
}
Solution Level 2
{
  "finest-div-error": 0.03228915024367091,
  "finest-p-error": 0.01653218924445144,
  "finest-u-error": 0.2494186937629489
}
Solution Level 3
{
  "finest-div-error": 0.02342587767298657,
  "finest-p-error": 0.0293669813583954,
  "finest-u-error": 0.2895144918378879
}
```

---
### Boundary Type 3
Boundary on left side set to 0.0 and 1.0 on right side, right hand side set to 0 elsewhere::
![dirichlet_spe10_2d_slice3](https://user-images.githubusercontent.com/13111488/45235075-96cd4280-b28c-11e8-87dd-212272c36350.png)
```sh
mpirun -np 8 ./dirichlet  -nr 1 -cf 0.4 -nl 4 -m 4  -t 1.0 -hb --dim 2 -vis --ml-factor 4 -bt 3 -bv 1                                                                                                                                                [63/18877]
Options used:
   --perm spe_perm.dat
   --dim 2
   --slice 0
   --max-evects 4
   --spect-tol 1
   --no-metis-agglomeration
   --part-unbalance 2
   --spe10-scale 5
   --hybridization
   --no-dual-target
   --no-scaled-dual
   --no-energy-dual
   --visualization
   --num-refine 1
   --coarse-factor 0.4
   --num-levels 4
   --ml-factor 4
   --boundary-type 3
   --boundary-value 1
Permeability file read in 2.00517.s 
Permeability field distributed in 0.0476321.s 
13370 fine edges, 0 fine faces, 6600 fine elements

GraphUpscale Setup Time:      1.56093

Processors: 8
---------------------

Level 0 Matrix
---------------------
M Size          106160
D Size          52800
+ Size          158960
NonZeros:       528560

Level 1 Matrix
---------------------
M Size          7744
D Size          2912
+ Size          10656
NonZeros:       232672

Op Comp:        1.57

Level 2 Matrix
---------------------
M Size          2376
D Size          736
+ Size          3112
NonZeros:       95464

Op Comp:        1.26

Level 3 Matrix
---------------------
M Size          568
D Size          192
+ Size          760
NonZeros:       21112

Op Comp:        1.06


Fine Solve Time:         0.220795
Fine Solve Iterations:   18

Level 1 Solve Time:       3.07861
Level 1 Solve Iterations: 208

Level 2 Solve Time:       0.0236282
Level 2 Solve Iterations: 141

Level 3 Solve Time:       0.00766989
Level 3 Solve Iterations: 111
Solution Level 1
{
  "finest-div-error": 1.717042859807937,
  "finest-p-error": 0.04584943033847692,
  "finest-u-error": 0.2250305496561937
}
Solution Level 2
{
  "finest-div-error": 1.189597757048728,
  "finest-p-error": 0.08823867708529942,
  "finest-u-error": 0.3344396830504429
}
Solution Level 3
{
  "finest-div-error": 0.8119694438922238,
  "finest-p-error": 0.1203860405873711,
  "finest-u-error": 0.4262374266358149
}
```